### PR TITLE
Quick Fix: Use of env variables for application.properties

### DIFF
--- a/demo/src/main/resources/application.properties
+++ b/demo/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=demo
-spring.datasource.url=jdbc:mariadb://localhost:3306/demo
-spring.datasource.username=demo
-spring.datasource.password=demo2024
+spring.datasource.url=${VOIAGE_JAVA_DB_CONN_STR}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWD}
 spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
-security.jwt.secret-key=3cfa76ef14937c1c0ea519f8fc057a80fcd04a7420f8e8bcd0a7567c272e007b
+security.jwt.secret-key= ${JWT_SECRET_KEY}
 security.jwt.expiration-time=3600000


### PR DESCRIPTION
Este cambio es para usar variables de entorno. En caso de encontrar una manera similar a dotenv en Node-Angular. De momento esta parece ser la forma de hacerlo.

NOTAS:

- Para Mac seter las env variables con este formato: export DB_USERNAME=myusername
- Para Windows pueden hacerlo de dos maneras, hacerlo desde CMD, no Powershell: set DB_USERNAME=myusername 

La otra manera en Windows es abrir las variables de entorno de la cuenta y agregarlas mediante el GUI.