### PR TITLE
Quick Fix for Trip Retrieve All

### DIFF
--- a/demo/src/main/java/com/project/demo/logic/TripService.java
+++ b/demo/src/main/java/com/project/demo/logic/TripService.java
@@ -32,7 +32,6 @@ public class TripService implements IService<Trip, Integer>{
 
             entity.getFlight().getLayovers().forEach(layover -> {
                     layover.setParentFlight(entity.getFlight());
-                    layover.setTrip(entity);
                 });
 
             entity.getFlight().setTrip(entity);


### PR DESCRIPTION
The trip was assigned to the layovers as well, this was causing the application to not retrieve the records since trip was only expecting one flight, but was getting more than one